### PR TITLE
Allow pink::keyPair to export private key

### DIFF
--- a/src/keys/pink.rs
+++ b/src/keys/pink.rs
@@ -38,6 +38,11 @@ impl KeyPair {
             .expect("Derive returned an invalid key");
         privkey.into()
     }
+
+    /// Exports the private key
+    pub fn private_key(&self) -> [u8; 32] {
+        self.privkey
+    }
 }
 
 impl Key for KeyPair {


### PR DESCRIPTION
When writing contracts, we can't store Keypair directly in the contract's storage, because Keypair doesn't derive the necessary ink storage layout traits, a workaround is to store the private key instead. We already have a method to restore `KeyPair` from the private key:

```rust
let keypair: KeyPair = self.key.into();
```