### PR TITLE
Upgrade eth libs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,11 @@ edition = "2021"
 [dependencies]
 arrayvec = { version = "0.7.1", default-features = false, features = ["serde"] }
 derive_more = "0.99.1"
-ethabi = { version = "17.2.0", package = "pink-ethabi", default-features = false, features = [
+ethabi = { version = "18.0.0", default-features = false, features = [
     "serde",
     "rlp",
 ] }
-ethereum-types = { version = "0.13.0", default-features = false, features = [
+ethereum-types = { version = "0.14.1", default-features = false, features = [
     "rlp",
     "serialize",
 ] }
@@ -38,7 +38,7 @@ ink_env = { version = "4", default-features = false, optional = true }
 
 [dev-dependencies]
 # For examples
-env_logger = "0.9"
+env_logger = "0.10.0"
 hex-literal = "0.3"
 serde_json = "1.0.85"
 futures = "0.3.5"


### PR DESCRIPTION
Upgrade dependencies:
- ethabi from 17.2.0 to 18.0.0, and change to upstream
- ethereum-types from 0.13.0 to 0.14.0